### PR TITLE
Add support for Dokku 0.11.3

### DIFF
--- a/commands
+++ b/commands
@@ -27,8 +27,7 @@ case "$1" in
     mkdir -p "$DOKKU_ROOT/$APP"
     docker pull "$DOCKER_REGISTRY_IMAGE"
     docker tag "$DOCKER_REGISTRY_IMAGE" "dokku/$APP"
-    dokku release "$APP"
-    dokku deploy "$APP"
+    dokku tags:deploy "$APP" latest
     ;;
 
   help | registry:help)


### PR DESCRIPTION
In Dokku 0.11.3, the `release` command is not supported anymore (see [the issue in the original repo](https://github.com/agco/dokku-registry/issues/5)). This commit uses the appropriate new command to restore this functionality.